### PR TITLE
Improve standard_room.py

### DIFF
--- a/euphoria/standard_room.py
+++ b/euphoria/standard_room.py
@@ -19,23 +19,18 @@ class StandardRoom(chat_room.ChatRoom):
         self.short_help_text = None
         self.help_text = None
 
-    def handle_message(self, data):  #TODO: This is quite hacky.
+    def handle_message(self, data):
         content = data["data"]["content"]
         reply = data["data"]["id"]
+        at_mention = '@' + ''.join(re.split(r'\s', self.nickname))
 
-        if content == "!ping":
+        if content.lower() == "!ping" or content.lower() == "!ping " + at_mention.lower():
             self.send_chat(self.ping_text, reply)
-        elif content == "!ping @" + self.nickname:
-            self.send_chat(self.ping_text, reply)
-
-        elif content == "!help":
-            if self.short_help_text is not None:
-                self.send_chat(self.short_help_text, reply)
-        elif content == "!help @" + self.nickname:
-            if self.help_text is not None:
-                self.send_chat(self.help_text, reply)
-
-        elif content == "!uptime @" + self.nickname:
+        elif content.lower() == "!help" and self.short_help_text:
+            self.send_chat(self.short_help_text, reply)
+        elif content.lower() == "!help " + at_mention.lower() and self.help_text:
+            self.send_chat(self.help_text, reply)
+        elif content.lower() == "!uptime " + at_mention.lower():
             u = datetime.datetime.strftime(self.start_utc, "%Y-%m-%d %H:%M:%S")
             t = utils.extract_time(self.uptime())
 


### PR DESCRIPTION
Some of the rationale behind the changes I made:
- `content.lower()` instead of `content` makes the command case-insensitive.
- `at_mention` handles nicknames with spaces (including Unicode spaces) properly.
- `and` makes the conditionals more concise and also allows the conditionals to fall-through to the bot's own `handle_message` handler if `self.short_help_text` or `self.help_text` is not defined, allowing bots to use custom dynamic help texts.
